### PR TITLE
Hotfix: Fix snappy encoding process

### DIFF
--- a/nsq/snappy_socket.py
+++ b/nsq/snappy_socket.py
@@ -43,4 +43,4 @@ class SnappyEncoder(object):
 
     @staticmethod
     def encode(data):
-        return snappy.compress(data)
+	return snappy.StreamCompressor().compress(data)


### PR DESCRIPTION
Replace compress method with using Compressor and its method compress
which automatically determinies the compression.